### PR TITLE
Fix: Add import yaml to DockerGen.py

### DIFF
--- a/DockerGen.py
+++ b/DockerGen.py
@@ -21,10 +21,12 @@ def check_dependencies():
         print("  pip install -r requirements.txt\n")
         sys.exit(1)  # Terminar ejecución si faltan paquetes
 
+
 # Verificar dependencias antes de continuar
 check_dependencies()
 
 # Importar rich y otras librerías
+import yaml
 from rich.console import Console
 from rich.prompt import Prompt, Confirm
 from rich.panel import Panel


### PR DESCRIPTION
Este commit arregla un error generado por la issue #2 .

## Descripción error
El programa no puede generar el fichero .yml porque no encuentra la dependencia `yaml`

## Solución
Importar la dependencia dentro del fichero después de asegurarse de que están instaladas